### PR TITLE
feat: implement pull request mergeability check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -940,40 +940,60 @@ module.exports = (app: Probot) => {
                 case "User":
                     // Merge pull request
                     if (context.payload.comment.body.toLowerCase() == "ready to merge") {
-                        if (context.payload.issue.user.login == context.payload.comment.user.login) {
-                            let i: number;
-                            for (i = 0; i < context.payload.issue.labels.length; i++) {
-                                if (context.payload.issue.labels[i].name == "Approved") {
-                                    console.log("Merging");
-                                    await context.octokit.pulls.merge({
-                                        repo: context.payload.repository.name,
-                                        owner: context.payload.repository.owner.login,
-                                        pull_number: context.payload.issue.number,
-                                        commit_title: `Merge PR #${context.payload.issue.number} ${context.payload.issue.title}`,
-                                        commit_message: context.payload.issue.title
-                                    });
-                                    console.log("Merged!");
-                                    await context.octokit.issues.createComment(
-                                        context.issue({
-                                            body: `Merged by ${context.payload.comment.user.login}!`
-                                        })
-                                    );
-                                    break;
-                                } else if (context.payload.issue.labels[i].name == "Requested Changes") {
-                                    console.log('PRs Blocked');
-                                    await context.octokit.issues.createComment(
-                                        context.issue({
-                                            body: `Merging blocked because PRs has requested changes! @${context.payload.comment.user.login}`
-                                        })
-                                    );
-                                    break;
+                        context.octokit.pulls.get({
+                            repo: context.payload.repository.name,
+                            owner: context.payload.repository.owner.login,
+                            pull_number: context.payload.issue.number
+                        }).then(async (res) => {
+                            if (res.data.mergeable_state.toLowerCase() == "clean" || res.data.mergeable == true) {
+                                if (context.payload.issue.user.login == context.payload.comment.user.login) {
+                                    let i: number;
+                                    for (i = 0; i < context.payload.issue.labels.length; i++) {
+                                        if (context.payload.issue.labels[i].name == "Approved") {
+                                            console.log("Merging");
+                                            await context.octokit.pulls.merge({
+                                                repo: context.payload.repository.name,
+                                                owner: context.payload.repository.owner.login,
+                                                pull_number: context.payload.issue.number,
+                                                commit_title: `Merge PR #${context.payload.issue.number} ${context.payload.issue.title}`,
+                                                commit_message: context.payload.issue.title
+                                            });
+                                            console.log("Merged!");
+                                            await context.octokit.issues.createComment(
+                                                context.issue({
+                                                    body: `Merged by ${context.payload.comment.user.login}!`
+                                                })
+                                            );
+                                            break;
+                                        } else if (context.payload.issue.labels[i].name == "Requested Changes") {
+                                            console.log("PRs Blocked");
+                                            await context.octokit.issues.createComment(
+                                                context.issue({
+                                                    body: `Merging blocked because PRs has requested changes! @${context.payload.comment.user.login}`
+                                                })
+                                            );
+                                            break;
+                                        } else {
+                                            continue;
+                                        }
+                                    }
                                 } else {
-                                    continue;
+                                    return;
                                 }
+                            } else if (res.data.mergeable_state.toLowerCase() == "dirty" || res.data.mergeable == false) {
+                                await context.octokit.issues.createComment(
+                                    context.issue({
+                                        body: `Merging blocked because PRs has merge conflict! @${context.payload.comment.user.login}`
+                                    })
+                                );
+                            } else if (res.data.mergeable == null) {
+                                await context.octokit.issues.createComment(
+                                    context.issue({
+                                        body: `give reply from automaton that github automaton can't proceed merging commit, please wait for any minute before attempting to merge it again.`
+                                    })
+                                );
                             }
-                        } else {
-                            return;
-                        }
+                        });
                     }
 
                     if (context.payload.comment.body.toLowerCase() == "merge") {


### PR DESCRIPTION
feature has been added to the codebase that enables the [API](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request) to check the mergeability of pull requests. ensures that a pull request is mergeable and prevent potential merge conflicts 

