### PR TITLE
fix: inaccessible pull_request number in workflow_run

### DIFF
--- a/src/class/workflowCheck.ts
+++ b/src/class/workflowCheck.ts
@@ -61,7 +61,7 @@ export default class WorkflowCheck {
             head: `${this.context.payload.workflow_run.actor.login}:${this.context.payload.workflow_run.head_branch}`,
             state: "open"
         }).then(async (res) => {
-            const prsNumber = res.data[0].number;
+            const prsNumber = res.data.find((a) => a.head.sha === this.context.payload.workflow_run.head_sha)?.number as number;
             if (this.context.payload.workflow_run.conclusion == "success") {
                 await this.context.octokit.pulls.get({
                     owner: this.context.payload.repository.owner.login,

--- a/src/class/workflowCheck.ts
+++ b/src/class/workflowCheck.ts
@@ -1,4 +1,4 @@
-import Context from "../index";
+import Context, { octokit } from "../index";
 
 /**
  * @class
@@ -9,13 +9,13 @@ export default class WorkflowCheck {
 
     /**
      * @private
-     * @type Context<"issues.closed">
+     * @type Context<"workflow_run.completed">
      */
     private context: Context<"workflow_run.completed">;
 
     /**
      * @constructor
-     * @param {Context<"issues.closed">} context
+     * @param {Context<"workflow_run.completed">} context
      */
     constructor(context: Context<"workflow_run.completed">) {
         this.context = context;
@@ -54,47 +54,56 @@ export default class WorkflowCheck {
      * @async
      * @returns {Promise<void>}
      */
-    public async CheckUserCI(): Promise<void> {
-        if (this.context.payload.workflow_run.conclusion == "success") {
-            await this.context.octokit.pulls.get({
-                owner: this.context.payload.repository.owner.login,
-                repo: this.context.payload.repository.name,
-                pull_number: this.context.payload.workflow_run.pull_requests[0].number
-            }).then(async (res) => {
-                if (res.data.labels.find(a => a.name == "CI Failed")) {
-                    await this.context.octokit.issues.removeLabel(
-                        this.context.issue({
-                            owner: this.context.payload.repository.owner.login,
-                            repo: this.context.payload.repository.name,
-                            issue_number: this.context.payload.workflow_run.pull_requests[0].number,
-                            name: "CI Failed"
-                        })
-                    );
-                    console.log("CI Passed!");
-                } else {
-                    return;
-                }
-            });
-        } else if (this.context.payload.workflow_run.conclusion == "failure") {
-            console.log("CI Failure!");
-            await this.context.octokit.issues.addLabels(
-                this.context.issue({
+    public async checkUserCI(): Promise<void> {
+        await octokit.rest.pulls.list({
+            owner: this.context.payload.repository.owner.login,
+            repo: this.context.payload.repository.name,
+            head: `${this.context.payload.workflow_run.actor.login}:${this.context.payload.workflow_run.head_branch}`,
+            state: "open"
+        }).then(async (res) => {
+            const prsNumber = res.data[0].number;
+            if (this.context.payload.workflow_run.conclusion == "success") {
+                await this.context.octokit.pulls.get({
                     owner: this.context.payload.repository.owner.login,
                     repo: this.context.payload.repository.name,
-                    issue_number: this.context.payload.workflow_run.pull_requests[0].number,
-                    labels: ["CI Failed"]
-                })
-            );
-            await this.context.octokit.issues.createComment(
-                this.context.issue({
-                    owner: this.context.payload.repository.owner.login,
-                    repo: this.context.payload.repository.name,
-                    issue_number: this.context.payload.workflow_run.pull_requests[0].number,
-                    body: `CI build failed! for more information please review the [logs](${this.context.payload.workflow_run.html_url}).`
-                })
-            );
-        } else {
-            return;
-        }
+                    pull_number: prsNumber
+                }).then(async (res) => {
+                    if (res.data.labels.find(a => a.name == "CI Failed")) {
+                        await this.context.octokit.issues.removeLabel(
+                            this.context.issue({
+                                owner: this.context.payload.repository.owner.login,
+                                repo: this.context.payload.repository.name,
+                                issue_number: prsNumber,
+                                name: "CI Failed"
+                            })
+                        );
+                        console.log("CI Passed!");
+                    } else {
+                        return;
+                    }
+                });
+            } else if (this.context.payload.workflow_run.conclusion == "failure") {
+                console.log("CI Failure!");
+                await this.context.octokit.issues.addLabels(
+                    this.context.issue({
+                        owner: this.context.payload.repository.owner.login,
+                        repo: this.context.payload.repository.name,
+                        issue_number: prsNumber,
+                        labels: ["CI Failed"]
+                    })
+                );
+                await this.context.octokit.issues.createComment(
+                    this.context.issue({
+                        owner: this.context.payload.repository.owner.login,
+                        repo: this.context.payload.repository.name,
+                        issue_number: prsNumber,
+                        body: `CI build failed! for more information please review the [logs](${this.context.payload.workflow_run.html_url}).`
+                    })
+                );
+            } else {
+                return;
+            }
+        });
     }
+
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,12 @@ const octokit = new Octokit({
         privateKey: process.env.PRIVATE_KEY,
         clientId: process.env.CLIENT_ID,
         clientSecret: process.env.CLIENT_SECRET,
-        installationId: 21573969
+        installationId: 12345678 // env not working
     }
 });
 
 module.exports = (app: Probot) => {
+
     app.on("push", async (context): Promise<void> => {
         await new Push(context).push();
     });
@@ -92,7 +93,7 @@ module.exports = (app: Probot) => {
     app.on("workflow_run.completed", async (context): Promise<void> => {
         if (context.payload.workflow_run.event == "pull_request") {
             if (context.payload.sender.type == "User") {
-                await new WorkflowCheck(context).CheckUserCI();
+                await new WorkflowCheck(context).checkUserCI();
             } else {
                 await new WorkflowCheck(context).checkCI();
             }
@@ -100,6 +101,7 @@ module.exports = (app: Probot) => {
             return;
         }
     });
+
 };
 
 setInterval(() => {


### PR DESCRIPTION
automaton encountered an error where the pull_request[0].number wasn't accessible within the workflow_run. pull_request would return an empty array when pull requests are made from forked repositories (outside main repository).

![image](https://github.com/Typeslint/github-AutoResponse/assets/67871937/d839e4a4-1850-4634-b3f7-4113edb7d8f7)
